### PR TITLE
fix: centurion effects not supporting grid effects

### DIFF
--- a/src/modules/lights/effects/color/beat-fade-out.ts
+++ b/src/modules/lights/effects/color/beat-fade-out.ts
@@ -52,6 +52,8 @@ export type BeatFadeOutCreateParams = BaseLightsEffectCreateParams & {
 export default class BeatFadeOut extends LightsEffect<BeatFadeOutProps> {
   private readonly nrSteps: number;
 
+  private readonly nrPhases: number;
+
   private lastBeat = new Date().getTime(); // in ms since epoch;
 
   private beatLength: number = 1; // in ms;
@@ -64,18 +66,19 @@ export default class BeatFadeOut extends LightsEffect<BeatFadeOutProps> {
       nrSteps,
     );
 
+    const nrPhases = Math.max(nrSteps, progressionMapperStrategy.getNrFixtures());
+
     let progressionStrategy: EffectProgressionStrategy;
     if (props.customCycleTime) {
       progressionStrategy = new EffectProgressionTickStrategy(props.customCycleTime);
     } else {
-      progressionStrategy = new EffectProgressionBeatStrategy(
-        progressionMapperStrategy.getNrFixtures(),
-      );
+      progressionStrategy = new EffectProgressionBeatStrategy(nrPhases);
     }
 
     super(lightsGroup, progressionStrategy, progressionMapperStrategy, props.direction);
 
     this.nrSteps = nrSteps;
+    this.nrPhases = nrPhases;
     this.props = props;
 
     if (this.props.customCycleTime) {
@@ -133,7 +136,7 @@ export default class BeatFadeOut extends LightsEffect<BeatFadeOutProps> {
         const { colors } = this.props;
         const progression = this.getProgression(new Date(), p);
 
-        const phase = Math.round(progression * this.getEffectNrFixtures());
+        const phase = Math.round(progression * this.nrPhases);
         const index = phase % this.nrSteps;
 
         const color = colors[index];

--- a/src/modules/lights/effects/progression-strategies/mappers/effect-progression-map-vertical-strategy.ts
+++ b/src/modules/lights/effects/progression-strategies/mappers/effect-progression-map-vertical-strategy.ts
@@ -3,6 +3,7 @@ import LightsGroupFixture from '../../../entities/lights-group-fixture';
 
 export default class EffectProgressionMapVerticalStrategy extends EffectProgressionMapStrategy {
   getNrFixtures(): number {
+    if (this.lightsGroup.gridSizeY == 0) return 1;
     return this.lightsGroup.gridSizeY * this.multiplier;
   }
 

--- a/src/modules/modes/centurion/centurion-mode.ts
+++ b/src/modules/modes/centurion/centurion-mode.ts
@@ -13,12 +13,16 @@ import { CenturionScreenHandler } from '../../handlers/screen';
 import { LightsEffectBuilder } from '../../lights/effects/lights-effect';
 import Wave from '../../lights/effects/color/wave';
 import Sparkle from '../../lights/effects/color/sparkle';
-import { SimpleBeatGenerator, BeatManager, BeatPriorities } from '../../beats';
+import { BeatManager, BeatPriorities, SimpleBeatGenerator } from '../../beats';
 import logger from '../../../logger';
 import LightsSwitchManager from '../../root/lights-switch-manager';
 import { FeatureEnabled, ServerSettingsStore } from '../../server-settings';
 import { ISettings } from '../../server-settings/server-setting';
 import RootLightsService from '../../root/root-lights-service';
+import {
+  LightsEffectDirection,
+  LightsEffectPattern,
+} from '../../lights/effects/lights-effect-pattern';
 
 const LIGHTS_HANDLER = 'SetEffectsHandler';
 const AUDIO_HANDLER = 'SimpleAudioHandler';
@@ -234,6 +238,24 @@ export default class CenturionMode extends BaseMode<
   }
 
   /**
+   * Get a random pattern to apply to the lights effects
+   * @private
+   */
+  private getRandomPattern(): LightsEffectPattern {
+    const enumValues = Object.values(LightsEffectPattern);
+    return enumValues[Math.floor(Math.random() * enumValues.length)];
+  }
+
+  /**
+   * Get a random direction to apply to the lights effects
+   * @private
+   */
+  private getRandomDirection(): LightsEffectDirection {
+    const enumValues = Object.values(LightsEffectDirection);
+    return enumValues[Math.floor(Math.random() * enumValues.length)];
+  }
+
+  /**
    * Get a random effect given a set of colors
    * @param colors
    * @private
@@ -241,7 +263,13 @@ export default class CenturionMode extends BaseMode<
   private getRandomParEffect(colors: RgbColor[]): LightsEffectBuilder {
     const effects = [
       {
-        effect: BeatFadeOut.build({ colors, enableFade: false, nrBlacks: 1 }),
+        effect: BeatFadeOut.build({
+          colors,
+          enableFade: false,
+          nrBlacks: 1,
+          pattern: this.getRandomPattern(),
+          direction: this.getRandomDirection(),
+        }),
         probability: 0.8,
       },
       {
@@ -249,7 +277,11 @@ export default class CenturionMode extends BaseMode<
         probability: 0.1,
       },
       {
-        effect: Wave.build({ colors: colors }),
+        effect: Wave.build({
+          colors: colors,
+          pattern: this.getRandomPattern(),
+          direction: this.getRandomDirection(),
+        }),
         probability: 0.1,
       },
     ];
@@ -264,11 +296,13 @@ export default class CenturionMode extends BaseMode<
       factor = factor - 0.1;
     }
 
+    console.log(factor);
+
     return (
       effects.find((effect, i) => {
         const previous = effects.slice(0, i).reduce((x, e) => x + e.probability, 0);
         return previous <= factor && previous + effect.probability > factor;
-      })?.effect || BeatFadeOut.build({ colors, enableFade: false })
+      })?.effect || effects[0].effect
     );
   }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Fix 2D effect mapping not being applied to Centurion effects. Also includes a fix for the BeatFadeOut Vertical pattern, as that previously caused all lights to be a static color.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_