### PR TITLE
fix: default disco floor channel order

### DIFF
--- a/src/seed/seedDiscoFloor.ts
+++ b/src/seed/seedDiscoFloor.ts
@@ -3,7 +3,7 @@ import RootLightsService, { LightsInGroup } from '../modules/root/root-lights-se
 export async function seedDiscoFloor(
   width: number,
   height: number,
-  channelOrder: number[] = [3, 2, 1, 0],
+  channelOrder: number[] = [3, 2, 0, 1],
 ) {
   if (channelOrder.length !== 4) {
     throw new Error('Channel order must contain exactly four panels.');


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Based on experience setting up the disco floor at Hubble.
This is the default for [the disco floor rented at GEWIS and at Hubble](https://www.verlichtedansvloeren.nl/verlichte-dansvloeren/6/vlak-led-dansvloer).

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_