### PR TITLE
feat(security): Add integration security for external screen/handler control

### DIFF
--- a/src/modules/handlers/screen/poster/local/local-poster-controller.ts
+++ b/src/modules/handlers/screen/poster/local/local-poster-controller.ts
@@ -140,6 +140,7 @@ export class LocalPosterController extends Controller {
    * @param req
    */
   @Security(SecurityNames.LOCAL, securityGroups.poster.privileged)
+  @Security(SecurityNames.INTEGRATION, ['setStaticPoster'])
   @Post('items/{id}/show')
   public async showStaticPoster(id: number, @Request() req: ExpressRequest): Promise<void> {
     const service = new LocalPosterService();

--- a/src/modules/handlers/screen/poster/local/local-poster-controller.ts
+++ b/src/modules/handlers/screen/poster/local/local-poster-controller.ts
@@ -140,7 +140,7 @@ export class LocalPosterController extends Controller {
    * @param req
    */
   @Security(SecurityNames.LOCAL, securityGroups.poster.privileged)
-  @Security(SecurityNames.INTEGRATION, ['setStaticPoster'])
+  @Security(SecurityNames.INTEGRATION, ['showStaticPoster'])
   @Post('items/{id}/show')
   public async showStaticPoster(id: number, @Request() req: ExpressRequest): Promise<void> {
     const service = new LocalPosterService();

--- a/src/modules/root/handler-controller.ts
+++ b/src/modules/root/handler-controller.ts
@@ -100,7 +100,7 @@ export class HandlerController extends Controller {
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.handler.base)
-  @Security(SecurityNames.INTEGRATION, ['getScreens'])
+  @Security(SecurityNames.INTEGRATION, ['getScreenHandlers'])
   @Get('screen')
   public getScreenHandlers(): HandlerResponse<ScreenResponse>[] {
     return this.handlersManager.getHandlers(Screen).map((h) => ({
@@ -111,7 +111,7 @@ export class HandlerController extends Controller {
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.handler.privileged)
-  @Security(SecurityNames.INTEGRATION, ['setHandler'])
+  @Security(SecurityNames.INTEGRATION, ['setScreenHandler'])
   @Post('screen/{id}')
   public async setScreenHandler(
     @Request() req: ExpressRequest,

--- a/src/modules/root/handler-controller.ts
+++ b/src/modules/root/handler-controller.ts
@@ -100,6 +100,7 @@ export class HandlerController extends Controller {
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.handler.base)
+  @Security(SecurityNames.INTEGRATION, ['getScreens'])
   @Get('screen')
   public getScreenHandlers(): HandlerResponse<ScreenResponse>[] {
     return this.handlersManager.getHandlers(Screen).map((h) => ({
@@ -110,6 +111,7 @@ export class HandlerController extends Controller {
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.handler.privileged)
+  @Security(SecurityNames.INTEGRATION, ['setHandler'])
   @Post('screen/{id}')
   public async setScreenHandler(
     @Request() req: ExpressRequest,


### PR DESCRIPTION
This PR includes integration scopes to enable external screen/handler control.

# Description

Concretely it adds the following scopes: 
- `showStaticPoster` scope to access POST `/handler/screen/poster/static/items/{id}/show` endpoint to set static poster.
- `getScreenHandlers` scope to access GET `/handler/screen` to fetch IDs of the screens.
-  `setScreenHandler` scope to access POST `/handler/screen/{id}` to set the handlers for the screens.

## Types of changes
- Security

